### PR TITLE
Make setup from scratch work again

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,13 +67,6 @@ GEM
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.2)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -185,11 +178,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.1.5)
       actionpack (= 5.1.5)
       activesupport (= 5.1.5)
@@ -311,7 +299,6 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara (~> 2.13)
-  coffee-rails (~> 4.2)
   database_cleaner
   figaro
   foreman
@@ -328,7 +315,6 @@ DEPENDENCIES
   puma (~> 3.7)
   pundit
   rails (~> 5.1.5)
-  rails_12factor
   rspec-rails
   rubocop
   ruby_audit

--- a/bin/setup
+++ b/bin/setup
@@ -32,14 +32,8 @@ chdir APP_ROOT do
     cp 'config/secrets.yml.example', 'config/secrets.yml'
   end
 
-  # puts "\n== Copy application.yml if development mode"
-  # puts "\n== as in production the configuration comes from the enviornment"
-  if Rails.env.development? && File.exist?('config/application.yml')
-    cp 'config/application.yml.example', 'config/application.yml'
-  end
-
-  puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  puts "\n== Run database migrations =="
+  system! 'bin/rails db:migrate'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'


### PR DESCRIPTION
Setup script wasn't working properly because

1. Rails.env is not available in bin/setup
2. `rails db:setup` was failing since schema.rb was missing from the repo